### PR TITLE
Wip check executables

### DIFF
--- a/ceph_cfg/__init__.py
+++ b/ceph_cfg/__init__.py
@@ -8,7 +8,7 @@ import os
 import platform
 import json
 import shutil
-import constants
+import util_which
 
 # local modules
 import utils
@@ -27,16 +27,6 @@ import keyring_use
 
 log = logging.getLogger(__name__)
 
-__virtualname__ = 'ceph'
-
-__has_salt = True
-
-try:
-    import salt.client
-    import salt.config
-except :
-    __has_salt = False
-
 
 class Error(Exception):
     """
@@ -46,13 +36,6 @@ class Error(Exception):
     def __str__(self):
         doc = self.__doc__.strip()
         return ': '.join([doc] + [str(a) for a in self.args])
-
-
-def __virtual__():
-    if not constants._path_lsblk:
-        log.info("Error 'lsblk' command not find.")
-        return False
-    return __virtualname__
 
 
 def partition_list():
@@ -149,7 +132,7 @@ def _update_partition(action, dev, description):
 
     utils.execute_local_command(
         [
-             constants._path_partprobe,
+             util_which.which_partprobe.path,
              dev,
         ],
     )
@@ -185,7 +168,7 @@ def zap(dev = None, **kwargs):
 
         utils.execute_local_command(
             [
-                constants._path_sgdisk,
+                util_which.which_sgdisk.path,
                 '--zap-all',
                 '--',
                 dev,
@@ -193,7 +176,7 @@ def zap(dev = None, **kwargs):
         )
         utils.execute_local_command(
             [
-                constants._path_sgdisk,
+                util_which.which_sgdisk.path,
                 '--clear',
                 '--mbrtogpt',
                 '--',

--- a/ceph_cfg/constants.py
+++ b/ceph_cfg/constants.py
@@ -1,22 +1,5 @@
 import os.path
 
-try:
-    from salt.utils import which as find_executable
-except:
-    from distutils.spawn import find_executable
-
-
-_path_lsblk = find_executable('lsblk')
-_path_ceph_disk = find_executable('ceph-disk')
-_path_partprobe = find_executable('partprobe')
-_path_sgdisk = find_executable('sgdisk')
-_path_ceph_authtool = find_executable('ceph-authtool')
-_path_ceph = find_executable('ceph')
-_path_ceph_mon = find_executable('ceph-mon')
-_path_ceph_rgw = find_executable('radosgw')
-_path_ceph_mds = find_executable('ceph-mds')
-_path_systemctl = find_executable('systemctl')
-
 JOURNAL_UUID = '45b0969e-9b03-4f30-b4c6-b4b80ceff106'
 OSD_UUID = '4fbd7e29-9d25-41b8-afd0-062c0ceff05d'
 

--- a/ceph_cfg/keyring.py
+++ b/ceph_cfg/keyring.py
@@ -9,6 +9,7 @@ import os.path
 import utils
 import mdl_query
 import constants
+import util_which
 
 
 log = logging.getLogger(__name__)
@@ -91,10 +92,11 @@ class keyring_implementation_base(object):
                     instead to create the keyring, otherwise authtool itself will generate one
             extra_args: any other extra arguments to be passed to ceph authtool"""
 
-        if constants._path_ceph_authtool is None:
-            raise Error("Could not find executable 'ceph-authtool'")
-
-        args=[constants._path_ceph_authtool, "-n", keyring_name, "--create-keyring", keyring_path]
+        args=[
+            util_which.which_ceph_authtool.path,
+            "-n", keyring_name,
+            "--create-keyring", keyring_path
+            ]
 
         if secret:
             args += ["--add-key", secret.strip()]

--- a/ceph_cfg/mdl_updater.py
+++ b/ceph_cfg/mdl_updater.py
@@ -11,6 +11,7 @@ import ConfigParser
 # local modules
 import constants
 import utils
+import util_which
 
 
 log = logging.getLogger(__name__)
@@ -127,9 +128,7 @@ class model_updater():
         """
         Get lsblk version as this is older on RHEL 7.2
         """
-        if constants._path_lsblk is None:
-            raise Error("Could not find executable 'lsblk'")
-        arguments = [ constants._path_lsblk, "--version" ]
+        arguments = [ util_which.which_lsblk.path, "--version" ]
         output = utils.execute_local_command(arguments)
         if output["retcode"] != 0:
             raise Error("Failed executing '%s' Error rc=%s, stdout=%s stderr=%s" % (
@@ -193,9 +192,7 @@ class model_updater():
             salt '*' sesceph.partitions_all
         '''
         part_map = {}
-        if constants._path_lsblk is None:
-            raise Error("Could not find executable 'lsblk'")
-        cmd = [ constants._path_lsblk] + self._lsblk_arguements()
+        cmd = [ util_which.which_lsblk.path ] + self._lsblk_arguements()
         output = utils.execute_local_command(cmd)
         if output['retcode'] != 0:
             raise Error("Failed running: lsblk --ascii --output-all")

--- a/ceph_cfg/mdl_updater_remote.py
+++ b/ceph_cfg/mdl_updater_remote.py
@@ -8,9 +8,9 @@ import shlex
 
 # Local imports
 import keyring
-import constants
 import utils
 import mdl_query
+import util_which
 
 
 log = logging.getLogger(__name__)
@@ -61,7 +61,7 @@ class model_updater_remote():
                 continue
             keyring_identity = keyring_obj.keyring_identity_get()
             arguments = [
-                constants._path_ceph,
+                util_which.which_ceph.path,
                 '--connect-timeout',
                 '5',
                 "--keyring",
@@ -90,7 +90,7 @@ class model_updater_remote():
         This is not normally needed as connect method has updated this information
         """
         prefix_arguments = [
-            constants._path_ceph
+            util_which.which_ceph.path
         ]
         postfix_arguments = [
             "-f",
@@ -113,7 +113,7 @@ class model_updater_remote():
 
     def auth_list(self):
         prefix_arguments = [
-            constants._path_ceph
+            util_which.which_ceph.path
         ]
         postfix_arguments = [
             "auth",
@@ -203,7 +203,7 @@ class model_updater_remote():
 
     def pool_list(self):
         prefix_arguments = [
-            constants._path_ceph
+            util_which.which_ceph.path
         ]
         postfix_arguments = [
             "-f",
@@ -235,7 +235,7 @@ class model_updater_remote():
         er_profile = kwargs.get("erasure_code_profile")
         crush_ruleset_name = kwargs.get("crush_ruleset")
         prefix_arguments = [
-            constants._path_ceph
+            util_which.which_ceph.path
         ]
         postfix_arguments = [
             'osd',
@@ -271,7 +271,7 @@ class model_updater_remote():
         if not name in self.model.pool_list.keys():
             return True
         prefix_arguments = [
-            constants._path_ceph
+            util_which.which_ceph.path
         ]
         postfix_arguments = [
             'osd',

--- a/ceph_cfg/mds.py
+++ b/ceph_cfg/mds.py
@@ -11,6 +11,7 @@ import keyring
 import model
 import mdl_updater
 import rados_client
+import util_which
 
 
 log = logging.getLogger(__name__)
@@ -30,7 +31,7 @@ class mds_ctrl(rados_client.ctrl_rados_client):
         super(mds_ctrl, self).__init__(**kwargs)
         self.service_name = "ceph-mds"
         # Set path to mds binary
-        self.path_service_bin = constants._path_ceph_mds
+        self.path_service_bin = util_which.which_ceph_mds.path
         self.mds_name = kwargs.get("name")
         self.port = kwargs.get("port")
         self.addr = kwargs.get("addr")

--- a/ceph_cfg/mon.py
+++ b/ceph_cfg/mon.py
@@ -16,6 +16,7 @@ import presenter
 import utils
 import constants
 import service
+import util_which
 
 
 log = logging.getLogger(__name__)
@@ -236,7 +237,7 @@ class mon_implementation_base(object):
         cluster_name
             Set the cluster name. Defaults to "ceph".
         """
-        if constants._path_ceph_mon is None:
+        if util_which.which_ceph_mon.path is None:
             raise Error("Could not find executable 'ceph-mon'")
 
         u = mdl_updater.model_updater(self.model)
@@ -276,7 +277,7 @@ class mon_implementation_base(object):
             if q.mon_active():
                 return True
             arguments = [
-                constants._path_systemctl,
+                util_which.which_systemctl.path,
                 "restart",
                 "ceph-mon@%s" % (self.model.hostname)
                 ]
@@ -310,7 +311,7 @@ class mon_implementation_base(object):
             self._create_monmap(path_monmap)
             os.chown(path_monmap, self.uid, self.gid)
             arguments = [
-                constants._path_ceph_authtool,
+                util_which.which_ceph_authtool.path,
                 "--create-keyring",
                 key_path,
                 "--import-keyring",
@@ -325,7 +326,7 @@ class mon_implementation_base(object):
                     output["stderr"]
                     ))
             arguments = [
-                constants._path_ceph_authtool,
+                util_which.which_ceph_authtool.path,
                 key_path,
                 "--import-keyring",
                 path_admin_keyring,
@@ -350,7 +351,7 @@ class mon_implementation_base(object):
                 os.chown(path_mon_dir, self.uid, self.gid)
             # now do install
             arguments = [
-                    constants._path_ceph_mon,
+                    util_which.which_ceph_mon.path,
                     "--mkfs",
                     "-i",
                     self.model.hostname,

--- a/ceph_cfg/osd.py
+++ b/ceph_cfg/osd.py
@@ -10,6 +10,7 @@ import constants
 import model
 import mdl_updater
 import mdl_query
+import util_which
 
 
 log = logging.getLogger(__name__)
@@ -261,11 +262,8 @@ class osd_ctrl(object):
                 if len(part_table.keys()) > 0:
                     return True
 
-
-        if not constants._path_ceph_disk:
-            raise Error("Error 'ceph-disk' command not find")
         arguments = [
-            constants._path_ceph_disk,
+            util_which.which_ceph_disk.path,
             '-v',
             'prepare',
             '--fs-type',

--- a/ceph_cfg/purger.py
+++ b/ceph_cfg/purger.py
@@ -8,6 +8,7 @@ import utils
 import mdl_updater
 import service
 import keyring
+import util_which
 
 log = logging.getLogger(__name__)
 
@@ -23,7 +24,7 @@ class Error(Exception):
 
 def service_shutdown_ceph():
     arguments = [
-            constants._path_systemctl,
+            util_which.which_systemctl.path,
             "stop",
             "ceph*",
             ]

--- a/ceph_cfg/rgw.py
+++ b/ceph_cfg/rgw.py
@@ -7,6 +7,7 @@ import shutil
 # Local imports
 import utils
 import constants
+import util_which
 import keyring
 import model
 import mdl_updater_remote
@@ -30,7 +31,7 @@ class rgw_ctrl(rados_client.ctrl_rados_client):
         super(rgw_ctrl, self).__init__(**kwargs)
         self.service_name = "ceph-radosgw"
         # Set path to rgw binary
-        self.path_service_bin = constants._path_ceph_rgw
+        self.path_service_bin = util_which.which_ceph_rgw.path
         self.rgw_name = kwargs.get("name")
 
 

--- a/ceph_cfg/service.py
+++ b/ceph_cfg/service.py
@@ -2,7 +2,7 @@ import logging
 
 
 import utils
-import constants
+import util_which
 
 
 log = logging.getLogger(__name__)
@@ -106,10 +106,6 @@ class init_system(object):
         return self._init_type_implementation.on_boot_disable(**kwargs)
 
 class init_system_systemd():
-    def __init__(self):
-        if constants._path_systemctl is None:
-            raise Error("Could not find executable 'systemctl'")
-
 
     def _get_systemctl_name(self, **kwargs):
         service = kwargs.get("service")
@@ -125,7 +121,7 @@ class init_system_systemd():
 
         systemctl_name = self._get_systemctl_name(**kwargs)
         arguments = [
-                constants._path_systemctl,
+                util_which.which_systemctl.path,
                 'show',
                 '--property',
                 'ActiveState',
@@ -157,7 +153,7 @@ class init_system_systemd():
     def start(self, **kwargs):
         systemctl_name = self._get_systemctl_name(**kwargs)
         arguments = [
-                constants._path_systemctl,
+                util_which.which_systemctl.path,
                 'start',
                 systemctl_name
             ]
@@ -174,7 +170,7 @@ class init_system_systemd():
     def stop(self, **kwargs):
         systemctl_name = self._get_systemctl_name(**kwargs)
         arguments = [
-                constants._path_systemctl,
+                util_which.which_systemctl.path,
                 'stop',
                 systemctl_name
             ]
@@ -191,7 +187,7 @@ class init_system_systemd():
     def restart(self, **kwargs):
         systemctl_name = self._get_systemctl_name(**kwargs)
         arguments = [
-                constants._path_systemctl,
+                util_which.which_systemctl.path,
                 'restart',
                 systemctl_name
             ]
@@ -210,7 +206,7 @@ class init_system_systemd():
 
         systemctl_name = self._get_systemctl_name(**kwargs)
         arguments = [
-                constants._path_systemctl,
+                util_which.which_systemctl.path,
                 'enable',
                 systemctl_name
             ]
@@ -219,7 +215,7 @@ class init_system_systemd():
     def on_boot_disable(self, **kwargs):
         systemctl_name = self._get_systemctl_name(**kwargs)
         arguments = [
-                constants._path_systemctl,
+                util_which.which_systemctl.path,
                 'disable',
                 systemctl_name
             ]

--- a/ceph_cfg/util_which.py
+++ b/ceph_cfg/util_which.py
@@ -1,0 +1,65 @@
+import logging
+
+# analagous to the unix command which but with memoization functions.
+try:
+    from salt.utils import which as find_executable
+except:
+    from distutils.spawn import find_executable
+
+log = logging.getLogger(__name__)
+
+
+def Property(func):
+    return property(**func())
+
+
+class Error(Exception):
+    """Base class for exceptions in this module."""
+    pass
+
+
+class ExecutableNotFound(Error):
+    """
+    Executable not found exception
+    """
+    def __init__(self, executable):
+        self.executable = executable
+        
+    def __str__(self):
+        return "Could not find executable '%s'" % (self.executable)
+
+
+class memoise_which:
+    """
+    memoization of the which command
+    """
+    def __init__(self,exec_name):
+        self.name = exec_name
+        self._path = None
+
+
+    @Property
+    def path():
+        doc = "the path to the exeutable"
+
+        def fget(self):
+            if not self._path is None:
+                return self._path
+            self._path = find_executable(self.name)
+            if self._path is None:
+                log.error("Could not find executable:", self.name)
+                raise ExecutableNotFound(self.name)
+            return self._path
+        return locals()
+
+
+which_ceph_authtool = memoise_which('ceph-authtool')
+which_ceph_disk = memoise_which('ceph-disk')
+which_ceph_mds = memoise_which('ceph-mds')
+which_ceph = memoise_which('ceph')
+which_ceph_mon = memoise_which('ceph-mon')
+which_ceph_rgw = memoise_which('radosgw')
+which_lsblk = memoise_which('lsblk')
+which_partprobe = memoise_which('partprobe')
+which_sgdisk = memoise_which('sgdisk')
+which_systemctl = memoise_which('systemctl')


### PR DESCRIPTION
util_which memoize the paths for executables when they are found and not when they are not found.

This was an issue for executables that where called in the same time SLS file as installed the executables.
