### PR TITLE
Wip ceph config parser

### DIFF
--- a/ceph_cfg/model.py
+++ b/ceph_cfg/model.py
@@ -1,4 +1,4 @@
-import ConfigParser
+from util_configparser import ConfigParserCeph as ConfigParser
 
 
 class version(object):
@@ -36,7 +36,7 @@ class model(object):
         self.part_pairent = {}
         self.partitions_osd = {}
         self.partitions_journal = {}
-        self.ceph_conf = ConfigParser.ConfigParser()
+        self.ceph_conf = ConfigParser()
         # list of (hostname,addr) touples
         self.mon_members = []
         self.hostname = None

--- a/ceph_cfg/tests/test_configparserceph.py
+++ b/ceph_cfg/tests/test_configparserceph.py
@@ -33,3 +33,14 @@ user 2 3 = mysql
         config.readfp(io.BytesIO(sample_config))
         value = config.get("mysqld", "user_2_3")
         assert value == "mysql"
+
+
+    def test_whitespace_as_underscore(self):
+        sample_config = """
+[mysqld]
+user_2 = mysql
+"""
+        config = ConfigParser()
+        config.readfp(io.BytesIO(sample_config))
+        value = config.get("mysqld", "user_2")
+        assert value == "mysql"

--- a/ceph_cfg/tests/test_configparserceph.py
+++ b/ceph_cfg/tests/test_configparserceph.py
@@ -1,0 +1,38 @@
+from ceph_cfg.util_configparser import ConfigParserCeph as ConfigParser
+
+import tempfile
+import os
+import io
+
+class Test_util_configparser(object):
+
+    def test_whitespace_none(self):
+        sample_config = """
+[mysqld]
+user2 = mysql
+"""
+        config = ConfigParser()
+        config.readfp(io.BytesIO(sample_config))
+        value = config.get("mysqld", "user2")
+        assert value == "mysql"
+
+
+    def test_whitespace(self):
+        sample_config = """
+[mysqld]
+user 2 = mysql
+"""
+        config = ConfigParser()
+        config.readfp(io.BytesIO(sample_config))
+        value = config.get("mysqld", "user_2")
+        assert value == "mysql"
+
+    def test_whitespace_two(self):
+        sample_config = """
+[mysqld]
+user 2 3 = mysql
+"""
+        config = ConfigParser()
+        config.readfp(io.BytesIO(sample_config))
+        value = config.get("mysqld", "user_2_3")
+        assert value == "mysql"

--- a/ceph_cfg/tests/test_configparserceph.py
+++ b/ceph_cfg/tests/test_configparserceph.py
@@ -1,7 +1,4 @@
 from ceph_cfg.util_configparser import ConfigParserCeph as ConfigParser
-
-import tempfile
-import os
 import io
 
 class Test_util_configparser(object):

--- a/ceph_cfg/util_configparser.py
+++ b/ceph_cfg/util_configparser.py
@@ -1,0 +1,12 @@
+import string
+import ConfigParser
+
+class ConfigParserCeph(ConfigParser.ConfigParser):
+
+    def optionxform(self, s):
+        """
+        Make config files with white space use '_'
+        """
+        s = string.replace(s.strip(), ' ', '_')
+        return s
+

--- a/ceph_cfg/utils.py
+++ b/ceph_cfg/utils.py
@@ -1,6 +1,6 @@
 import logging
 import os
-import ConfigParser
+from util_configparser import ConfigParserCeph as ConfigParser
 import base64
 import binascii
 
@@ -53,7 +53,7 @@ def _get_cluster_uuid_from_name(cluster_name):
     configfile = "/etc/ceph/%s.conf" % (cluster_name)
     if not os.path.isfile(configfile):
         raise Error("Cluster confg file does not exist:'%s'" % configfile)
-    config = ConfigParser.ConfigParser()
+    config = ConfigParser()
     config.read(configfile)
     try:
         fsid = config.get("global","fsid")
@@ -70,7 +70,7 @@ def _get_cluster_name_from_uuid(cluster_uuid):
         fullpath = os.path.join("/etc/ceph/", file_name)
         print fullpath
 
-        config = ConfigParser.ConfigParser()
+        config = ConfigParser()
         config.read(fullpath)
         try:
             fsid = config.get("global","fsid")


### PR DESCRIPTION
The ceph-cfg also requires underscores in the key names, whereas Ceph allows spaces as word separators (and hyphens, for that matter). So "mon initial members" fails, expecting "mon_initial_members", this PR fixes this issue.
