### PR TITLE
Wip single timeout

### DIFF
--- a/ceph_cfg/__init__.py
+++ b/ceph_cfg/__init__.py
@@ -296,7 +296,7 @@ def keyring_auth_del(**kwargs):
             cluster_name
                 Set the cluster name. Defaults to "ceph".
     """
-    return keyring_use.keyring_auth_add_type(**kwargs)
+    return keyring_use.keyring_auth_del_type(**kwargs)
 
 
 def keyring_admin_create(**kwargs):

--- a/ceph_cfg/constants.py
+++ b/ceph_cfg/constants.py
@@ -11,3 +11,5 @@ _path_ceph_lib_rgw = os.path.join(_path_ceph_lib,"radosgw")
 _path_ceph_lib_mds = os.path.join(_path_ceph_lib,"mds")
 
 
+# Make time out 2 mins for remote operations
+ceph_remote_call_timeout = 120

--- a/ceph_cfg/constants.py
+++ b/ceph_cfg/constants.py
@@ -12,4 +12,4 @@ _path_ceph_lib_mds = os.path.join(_path_ceph_lib,"mds")
 
 
 # Make time out 2 mins for remote operations
-ceph_remote_call_timeout = 120
+ceph_remote_call_timeout = 20

--- a/ceph_cfg/constants.py
+++ b/ceph_cfg/constants.py
@@ -11,5 +11,5 @@ _path_ceph_lib_rgw = os.path.join(_path_ceph_lib,"radosgw")
 _path_ceph_lib_mds = os.path.join(_path_ceph_lib,"mds")
 
 
-# Make time out 2 mins for remote operations
+# Make time out in seconds for remote operations
 ceph_remote_call_timeout = 20

--- a/ceph_cfg/mdl_updater_remote.py
+++ b/ceph_cfg/mdl_updater_remote.py
@@ -209,7 +209,7 @@ class model_updater_remote():
         postfix_arguments = [
             "auth",
             "del",
-            keyringobj.keyring_path_get()
+            keyringobj.keyring_identity_get()
             ]
         connection_arguments = self.connection_arguments_get()
         arguments = prefix_arguments + connection_arguments + postfix_arguments

--- a/ceph_cfg/mdl_updater_remote.py
+++ b/ceph_cfg/mdl_updater_remote.py
@@ -11,6 +11,7 @@ import keyring
 import utils
 import mdl_query
 import util_which
+import constants
 
 
 log = logging.getLogger(__name__)
@@ -41,7 +42,7 @@ class model_updater_remote():
         if self.keyring_type != None:
             return [
                     '--connect-timeout',
-                    '5',
+                    '%s' % (constants.ceph_remote_call_timeout),
                     "--keyring",
                     self.keyring_path,
                     "--name",
@@ -63,7 +64,7 @@ class model_updater_remote():
             arguments = [
                 util_which.which_ceph.path,
                 '--connect-timeout',
-                '5',
+                '%s' % (constants.ceph_remote_call_timeout),
                 "--keyring",
                 keyring_path,
                 "--name",
@@ -171,13 +172,17 @@ class model_updater_remote():
         q = mdl_query.mdl_query(self.model)
         if q.mon_is() and q.mon_quorum() is False:
             raise Error("mon daemon is not in quorum")
-        arguments = [
-                "ceph",
-                "auth",
-                "import",
-                "-i",
-                keyringobj.keyring_path_get()
-                ]
+        prefix_arguments = [
+            util_which.which_ceph.path
+        ]
+        postfix_arguments = [
+            "auth",
+            "import",
+            "-i",
+            keyringobj.keyring_path_get()
+            ]
+        connection_arguments = self.connection_arguments_get()
+        arguments = prefix_arguments + connection_arguments + postfix_arguments
         output = utils.execute_local_command(arguments)
         if output["retcode"] != 0:
             raise Error("Failed executing '%s' Error rc=%s, stdout=%s stderr=%s" % (
@@ -198,12 +203,16 @@ class model_updater_remote():
         q = mdl_query.mdl_query(self.model)
         if q.mon_is() and q.mon_quorum() is False:
             raise Error("mon daemon is not in quorum")
-        arguments = [
-                "ceph",
-                "auth",
-                "del",
-                keyringobj.keyring_path_get()
-                ]
+        prefix_arguments = [
+            util_which.which_ceph.path
+        ]
+        postfix_arguments = [
+            "auth",
+            "del",
+            keyringobj.keyring_path_get()
+            ]
+        connection_arguments = self.connection_arguments_get()
+        arguments = prefix_arguments + connection_arguments + postfix_arguments
         output = utils.execute_local_command(arguments)
         if output["retcode"] != 0:
             raise Error("Failed executing '%s' Error rc=%s, stdout=%s stderr=%s" % (


### PR DESCRIPTION
Fix timeouts being too short for ceph operation with slower systems.

Fixes the following bug: https://github.com/oms4suse/sesceph/issues/35

Signed-off-by: Owen Synge osynge@suse.com
