### PR TITLE
Wip util which not all arguments converted

### DIFF
--- a/ceph_cfg/tests/test_util_which.py
+++ b/ceph_cfg/tests/test_util_which.py
@@ -1,0 +1,29 @@
+import ceph_cfg.util_which
+import mock
+import pytest
+
+
+def find_executable_yes(executable):
+    return '/usr/sbin/parted'
+
+
+def find_executable_no(executable):
+    return None
+
+
+class Test_mdl_updater_lsblk_version(object):
+    def setup(self):
+        self.which = ceph_cfg.util_which.memoise_which('sdsdsd')
+
+
+    @mock.patch('ceph_cfg.util_which.find_executable', find_executable_yes)
+    def test_find_executable_yes(self):
+        assert self.which.path == '/usr/sbin/parted'
+        
+        
+    @mock.patch('ceph_cfg.util_which.find_executable', find_executable_no)
+    def test_find_executable_no(self):
+        with pytest.raises(ceph_cfg.util_which.ExecutableNotFound) as excinfo:
+            self.which.path
+        assert 'Could not find executable' in str(excinfo.value)
+        assert 'sdsdsd' in str(excinfo.value)

--- a/ceph_cfg/util_which.py
+++ b/ceph_cfg/util_which.py
@@ -19,14 +19,7 @@ class Error(Exception):
 
 
 class ExecutableNotFound(Error):
-    """
-    Executable not found exception
-    """
-    def __init__(self, executable):
-        self.executable = executable
-        
-    def __str__(self):
-        return "Could not find executable '%s'" % (self.executable)
+    pass
 
 
 class memoise_which:
@@ -47,8 +40,9 @@ class memoise_which:
                 return self._path
             self._path = find_executable(self.name)
             if self._path is None:
-                log.error("Could not find executable:", self.name)
-                raise ExecutableNotFound(self.name)
+                msg = "Could not find executable:{executable}".format(executable=self.name)
+                log.error(msg)
+                raise ExecutableNotFound(msg)
             return self._path
         return locals()
 


### PR DESCRIPTION
It seems old style logging without pre formatting the message does not work with salt.

Signed-off-by: Owen Synge osynge@suse.com
