### PR TITLE
Bf no connection exception

### DIFF
--- a/ceph_cfg/remote_connection.py
+++ b/ceph_cfg/remote_connection.py
@@ -37,7 +37,7 @@ class connection():
     def arguments_get(self):
         if not self.has_connected():
             self.connect()
-        if self.has_connected:
+        if self.has_connected():
             return [
                     '--connect-timeout',
                     '%s' % (constants.ceph_remote_call_timeout),

--- a/ceph_cfg/tests/test_keyring.py
+++ b/ceph_cfg/tests/test_keyring.py
@@ -1,0 +1,21 @@
+import ceph_cfg.model
+import ceph_cfg.keyring
+
+
+class Test_keyring(object):
+    def setup(self):
+        mdl = ceph_cfg.model.model()
+        mdl.cluster_name = "ceph"
+        self.keyring = ceph_cfg.keyring.keyring_facard(mdl)
+
+
+    def test_keyring_types_path_get(self):
+        for keyring_type in ["admin", "mds", "mon", "osd", "rgw"]:
+            self.keyring.key_type = keyring_type
+            assert self.keyring.keyring_path_get() != None
+
+
+    def test_keyring_types_keyring_identity(self):
+        for keyring_type in ["admin", "mds", "mon", "osd", "rgw"]:
+            self.keyring.key_type = keyring_type
+            assert self.keyring.keyring_identity_get() != None

--- a/ceph_cfg/tests/test_remote_connection.py
+++ b/ceph_cfg/tests/test_remote_connection.py
@@ -1,0 +1,37 @@
+import pytest
+import ceph_cfg.model
+import ceph_cfg.keyring
+import ceph_cfg.remote_connection
+import mock
+
+
+def mock_connection_fail(*args):
+    output= {
+        'stdout' : "Could not connect\n",
+        'stderr' : "",
+        'retcode' : 1
+        }
+    return output
+
+
+class Test_remote_connection(object):
+    def setup(self):
+        self.mdl = ceph_cfg.model.model()
+        self.mdl.cluster_name = "ceph"
+        self.remote_connection = ceph_cfg.remote_connection.connection(self.mdl)
+
+
+    def test_arguments_get_connection(self):
+        self.mdl.connection.keyring_type = "admin"
+        self.mdl.connection.keyring_path = "/etc/ceph/ceph.client.admin.keyring"
+        self.mdl.connection.keyring_identity = "client.admin"
+        args_list = self.remote_connection.arguments_get()
+        assert self.mdl.connection.keyring_path in args_list
+        assert self.mdl.connection.keyring_identity in args_list
+
+
+    @mock.patch('ceph_cfg.utils.execute_local_command', mock_connection_fail)
+    def test_arguments_get_no_connection(self):
+        with pytest.raises(ceph_cfg.remote_connection.Error) as excinfo:
+            self.remote_connection.arguments_get()
+        assert 'Failed to connect to cluster' in str(excinfo.value)


### PR DESCRIPTION
When the cluster is down, strange exceptions where being thrown after a long delay.

This bug fix identifies the issue, and throws a clear exception.