### PR TITLE
 allow .conf files without explicit '[global]' section

### DIFF
--- a/ceph_cfg/tests/test_configparserceph.py
+++ b/ceph_cfg/tests/test_configparserceph.py
@@ -61,3 +61,13 @@ class Test_util_configparser(object):
         config.read(file_name)
         value = config.get("mysqld", "user_2")
         assert value == "mysql"
+
+
+    def test_no_global_section(self):
+        config = ConfigParser()
+        file_name = os.path.join(self.test_dir,"file")
+        with open(file_name, 'wt') as fp:
+            fp.write("user2 = mysql")
+        config.read(file_name)
+        value = config.get("global", "user2")
+        assert value == "mysql"

--- a/ceph_cfg/util_configparser.py
+++ b/ceph_cfg/util_configparser.py
@@ -1,3 +1,4 @@
+from io import StringIO
 try:
     import ConfigParser
 except:
@@ -14,3 +15,36 @@ class ConfigParserCeph(ConfigParser.ConfigParser):
         replaced = stripped.replace(' ', '_')
         return replaced
 
+
+    def _MissingSectionHeaderError_read(self,file_name):
+        vfile = StringIO(u'[global]\n%s' % open(file_name).read())
+        return ConfigParser.ConfigParser.readfp(self, vfile)
+
+
+    def read(self, filenames):
+        """Read and parse a filename or a list of filenames.
+
+        Files that cannot be opened are silently ignored; this is
+        designed so that you can specify a list of potential
+        configuration file locations (e.g. current directory, user's
+        home directory, systemwide directory), and all existing
+        configuration files in the list will be read.  A single
+        filename may also be given.
+
+        Return list of successfully read files.
+        """
+        if isinstance(filenames, ("".__class__, u"".__class__)):
+            filenames = [filenames]
+        read_ok = []
+        for filename in filenames:
+            try:
+                fp = open(filename)
+            except IOError:
+                continue
+            try:
+                self._read(fp, filename)
+            except ConfigParser.MissingSectionHeaderError:
+                self._MissingSectionHeaderError_read(filename)
+            fp.close()
+            read_ok.append(filename)
+        return read_ok


### PR DESCRIPTION
This PR fixes:

https://github.com/oms4suse/python-ceph-cfg/issues/16

It is inspired by https://github.com/oms4suse/python-ceph-cfg/pull/35 from bsanders 

It allows ceph config files to have no section header.

Signed-off-by: Owen Synge <osynge@suse.com>