### PR TITLE
Move to pytest in setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,5 @@ with-coverage=0
 cover-inclusive=0
 cover-package=0
 with-xunit=1
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -22,26 +22,21 @@ except ImportError:
 from setuptools.command.test import test as TestCommand
 import sys
 
-class Tox(TestCommand):
-    user_options = [('tox-args=', 'a', "Arguments to pass to tox")]
+
+class PyTest(TestCommand):
+    user_options = [('pytest-args=', 'a', "Arguments to pass to pytest")]
+
     def initialize_options(self):
         TestCommand.initialize_options(self)
-        self.tox_args = None
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
+        self.pytest_args = []
+
     def run_tests(self):
-        #import here, cause outside the eggs aren't loaded
-        import tox
         import shlex
-        args = self.tox_args
-        if args:
-            args = shlex.split(self.tox_args)
-        else:
-            args = ['-c', 'tox.ini']
-        errno = tox.cmdline(args=args)
+        #import here, cause outside the eggs aren't loaded
+        import pytest
+        errno = pytest.main(shlex.split(self.pytest_args))
         sys.exit(errno)
+
 
 setup(name='ceph_cfg',
     version=version,
@@ -73,5 +68,5 @@ setup(name='ceph_cfg',
         'pytest >=2.1.3',
         'mock >=1.0b1',
         ],
-    cmdclass = {'test': Tox},
+    cmdclass = {'test': PyTest},
     )


### PR DESCRIPTION
We shodul not use tox in setup.py as it limits portability and makes
nasty
things happen on soem build systems

Signed-off-by: Owen Synge <osynge@googlemail.com>